### PR TITLE
[fix](web)Update README(remove H1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Ralph Hightower Sushi Repository 
-
-Will build on Sushi recipes and have checklists of menu items from Sushi restaurants. 
+This will have checklists of menu items from Sushi restaurants.
 
 |   |
 |---|


### PR DESCRIPTION
- Jekyll seems to have a problem with duplicate H1.