### PR TITLE
[feat](web): _config works. Add Camo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Ralph Hightower Sushi — Home Page 
+
 This will have checklists of menu items from Sushi restaurants.
 
 |   |

--- a/SC/Columbia/CamonJapanese.md
+++ b/SC/Columbia/CamonJapanese.md
@@ -1,0 +1,108 @@
+# [Camon Japanese Restaurant](https://www.camonjapaneserestaurant.com/)
+
+## Menu
+
+### Appetizers
+
+- [ ] Egg Roll $8.00
+- [ ] Edamame $7.00
+- [ ] Gyoza (Steamed or Fried) $8.00
+- [ ] Sumai $8.00
+- [ ] Yakitori $7.50
+- [ ] Veg Tempura $7.00
+- [ ] Shrimp Tempura $10.00
+- [ ] Veg/Shrimp Tempura $8.00
+- [ ] Soft Shell Crab Tempura $11.00
+- [ ] Hika Yakko $6.50
+- [ ] Agedofu $8.00
+- [ ] Yudofu $8.00
+- [ ] Tako Yaki (8 pc) $10.00
+- [ ] Tuna Tataki $18.00
+
+### Soups, Salads, Sides
+
+- [ ] Misoshiru $3.50
+- [ ] Osumashi $3.50
+- [ ] House Salad $4.00
+- [ ] Seaweed Salad $5.50
+- [ ] Sunomono $8.00
+- [ ] Steamed White Rice $3.00
+- [ ] Sushi Rice $4.00
+
+### Nigiri 2pc/Sashimi 5pc
+
+- [ ] Scallop $8.00/$20.00
+- [ ] Tilapia $6.00/$15.00
+- [ ] Ebi (Shrimp) $6.00/$15.00
+- [ ] Ama Ebi (Sweet Shrimp) $10.00/$25.00
+- [ ] Hamachi (Yellowtail) $8.00/$20.00
+- [ ] Ika (Squid) $6.00/$15.00
+- [ ] Ikura (Salmon Roe) $10.00
+- [ ] Maguro (Tuna) $8.00/$20.00
+- [ ] Saba (Mackerel) $6.00/$15.00
+- [ ] Sake (Salmon) $8.00/$20.00
+- [ ] Hokki Gai (Shellfish) $6.00/$15.00
+- [ ] Tako (Octopus) $6.00/$15.00
+- [ ] Tamago (Omelet) $6.00/$15.00
+- [ ] Tobiko (Flying Fish Roe) $6.00
+- [ ] Unagi (Eel) $8.00/$20.00
+- [ ] Anago (Sea Eel) $10.00/$25.00
+
+### Makimono- Camon House Rolls
+- [ ] Tekka (Tuna Roll) $7.00
+- [ ] Sake (Salmon Roll) $7.00
+- [ ] Hamachi (Yellowtail Roll) $7.00
+- [ ] Salmon Skin Roll $6.00
+- [ ] Shrimp Tempura Roll $8.00
+- [ ] Crunchy Roll (Shrimp, Tuna, or Salmon) $11.00
+- [ ] California Roll $9.50
+- [ ] Eel Roll $10.00
+- [ ] Philadelphia Roll $9.50
+
+### Makimono- Veggie Rolls
+
+- [ ] Spicy Tempura Asparagus Roll $6.00
+- [ ] Veggie Tempura Roll $8.50
+- [ ] Bar Roll $9.00
+- [ ] Joe Roll $11.00
+- [ ] Toby Roll $9.00
+- [ ] Himali Roll $10.00
+
+### Makimono- Special Rolls
+
+- [ ] Camon Roll $11.00
+- [ ] Camon II $13.00
+- [ ] Camon III $13.00
+- [ ] Rainbow Roll $13.00
+- [ ] California Bay Roll $12.00
+- [ ] Lifesaver Roll $13.00
+- [ ] Tiffany Roll $12.00
+- [ ] Candy Roll $13.00
+- [ ] Kani-Veggie Roll $12.00
+- [ ] Honeymoon Roll $17.00
+- [ ] Spider Roll $12.00
+- [ ] Dragon Roll Special $17.00
+
+### Entrees
+
+- [ ] Tempura Udon/Soba $20.00
+- [ ] Tonkatsu Japanese Curry $22.00
+- [ ] Beef Japanese Curry $20.00
+- [ ] Shrimp Japanese Curry $20.00
+- [ ] Chicken Japanese Curry $20.00
+- [ ] Tofu Japanese Curry $18.00
+- [ ] Beef Teriyaki $25.00
+- [ ] Salmon Teriyaki $22.00
+- [ ] Shrimp Teriyaki $21.00
+- [ ] Chicken Teriyaki $19.00
+- [ ] Tofu Teriyaki $18.00
+- [ ] Karage (5 pc) $19.00
+- [ ] Tonkatsu $20.00
+- [ ] Sarua Soba $10.00
+
+### Dessert
+
+- [ ] Mochi Ice Cream (assorted flavors) $3.25
+- [ ] Vanilla Ice Cream with Azuki Bean $3.50
+- [ ] Yuzu Cheesecake $3.50
+- [ ] Green Tea Cheesecake $3.50

--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,7 @@ plugins:
  - "jekyll-last-modified-at"
 # - "jekyll-titles-from-headings"
 
+# 2024-05-06 This looks like the right settings where Jekyll won't display two H1s.
 titles_from_headings:
   enabled: true
   strip_title: true


### PR DESCRIPTION
- _config.yml
   - 2024-05-06 This looks like the right settings where Jekyll won't display two H1s.
      - titles_from_headings:
         - enabled: true
         - strip_title: true
         - collections: false
- README.md
   - H1: Ralph Hightower Sushi — Home Page
- SC
   - Columbia
      - CamonJapanese.md